### PR TITLE
Add Norsk family starting with NSF2022 lexicon.

### DIFF
--- a/dbmaker/dbmaker.go
+++ b/dbmaker/dbmaker.go
@@ -759,6 +759,7 @@ func populateAlphsDefs(filename string, combinations func(string, bool) uint64,
 		if len(fields) > 0 {
 			word := common.InitializeWord(strings.ToUpper(fields[0]), dist)
 			definition := ""
+			log.Info().Msgf("word %v", word)
 			if len(fields) > 1 {
 				definition = strings.Join(fields[1:], " ")
 			}

--- a/dbmaker/lexicon_info.go
+++ b/dbmaker/lexicon_info.go
@@ -30,6 +30,7 @@ const (
 	FamilyOSPS               = "OSPS"
 	FamilyDeutsch            = "Deutsch"
 	FamilyFrench             = "FRA"
+	FamilyNorsk              = "Norsk"
 )
 
 type LexiconMap map[FamilyName]LexiconFamily

--- a/dbmaker/utils.go
+++ b/dbmaker/utils.go
@@ -44,6 +44,10 @@ func LexiconMappings(dataPath string) LexiconMap {
 	if err != nil {
 		panic(err)
 	}
+	norwegianLD, err := tilemapping.NamedLetterDistribution(cfg, "norwegian")
+	if err != nil {
+		panic(err)
+	}
 
 	lexiconPath := filepath.Join(dataPath, "lexica")
 
@@ -203,6 +207,17 @@ func LexiconMappings(dataPath string) LexiconMap {
 		},
 	}
 
+	norskFamily := []*LexiconInfo{
+		{
+			LexiconName:        "NSF2022",
+			LexiconFilename:    filepath.Join(lexiconPath, "NSF2022.txt"),
+			KWG:                loadKWG(dataPath, "NSF2022"),
+			LexiconIndex:       25,
+			DescriptiveName:    "Norsk Scrabbleforbund 2022",
+			LetterDistribution: norwegianLD,
+		},
+	}
+
 	frenchFamily := []*LexiconInfo{
 		{
 			LexiconName:        "FRA20",
@@ -228,6 +243,7 @@ func LexiconMappings(dataPath string) LexiconMap {
 		FamilyOSPS:    ospsFamily,
 		FamilyDeutsch: deutschFamily,
 		FamilyFrench:  frenchFamily,
+		FamilyNorsk:   norskFamily,
 	}
 
 	return lexiconMap


### PR DESCRIPTION
Adds Norsk NSF2022 to word-db-server. NSF2022 only builds in word-db-server if the word "MENNESKERETTIGHETSBEVEGELSENE" is removed from the list. I don't think this is a big deal since that word is greater than 15 letters.